### PR TITLE
Fix #26 - Avoid notifying unassigned SharedArrayBuffer entry

### DIFF
--- a/esm/channel.js
+++ b/esm/channel.js
@@ -1,5 +1,5 @@
 // ⚠️ AUTOMATICALLY GENERATED - DO NOT CHANGE
-export const CHANNEL = '004aa280-89ed-4d6d-ba35-756aa263a436';
+export const CHANNEL = '8db0a6b1-4d79-4ecd-8b7a-7ea5c1811764';
 
 export const MAIN = 'M' + CHANNEL;
 export const THREAD = 'T' + CHANNEL;

--- a/esm/index.js
+++ b/esm/index.js
@@ -104,7 +104,7 @@ const coincident = (self, {parse = JSON.parse, stringify = JSON.stringify, trans
           const length = sb[0];
 
           // filter undefined results
-          if (!length) return;
+          if (length < 0) return;
 
           // calculate the needed ui16 bytes length to store the result string
           const bytes = UI16_BYTES * length;
@@ -146,7 +146,9 @@ const coincident = (self, {parse = JSON.parse, stringify = JSON.stringify, trans
                   try {
                     // await for result either sync or async and serialize it
                     const result = await actions.get(action)(...args);
-                    if (result !== void 0) {
+                    if (result === void 0)
+                      sb[0] = -1; // @see https://github.com/WebReflection/coincident/issues/26
+                    else {
                       const serialized = stringify(transform ? transform(result) : result);
                       // store the result for "the very next" event listener call
                       results.set(id, serialized);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coincident",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coincident",
-      "version": "0.13.4",
+      "version": "0.13.5",
       "license": "ISC",
       "dependencies": {
         "@ungap/structured-clone": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coincident",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "An Atomics based Proxy to simplify, and synchronize, Worker related tasks",
   "main": "./cjs/index.js",
   "types": "./types/index.d.ts",

--- a/test/issue-26/index.html
+++ b/test/issue-26/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type="module">
+    console.log('main');
+    import coincident from '../../es.js';
+    const proxy = coincident(new Worker('./worker.js', {type: 'module'}));
+    let func_calls = 0;
+    proxy.func = () => {
+      func_calls++;
+      if (func_calls % 1000 == 0)
+        console.log(`func: ${func_calls}`);
+    }
+  </script>
+</head>
+</html>

--- a/test/issue-26/worker.js
+++ b/test/issue-26/worker.js
@@ -1,0 +1,9 @@
+console.log('worker.js');
+
+import coincident from '../../es.js';
+const proxy = coincident(self);
+
+(async () => {
+  for (let i = 0; i < 100000; i++)
+    proxy.func();
+})();


### PR DESCRIPTION
This MR avoids a very subtle bug that is hard to repeat consistently but that, to my understanding, boils down to this issue:

  * if the shared array buffer is not changed but notified as "*nothing to return*" without an explicit value set to its index `[0]` then `Atomics.wait(sb, 0, 0, delay)` **might** fail unexpectedly without any warning whatsoever
  * if the shared array buffer has an explicit value set at index `[0]` then everything **always** works as expected
  * if the remote function returns a value, hence it assign some length to the `[0]` it always works too

I have no idea if it's worth it to me to file a bug to all vendors as I think this is an intended behavior.

### Changes

  * be sure that if the remote call does not return anything (`undefined`) a value at index `[0]` is set as `-1` so that negative result length means no further actions need to be performed
  * when the `length` is indeed less than zero, early return without asking for data to unserialize