### PR TITLE
A better fix for the Atomics.wait with costrol value

### DIFF
--- a/esm/channel.js
+++ b/esm/channel.js
@@ -1,5 +1,5 @@
 // ⚠️ AUTOMATICALLY GENERATED - DO NOT CHANGE
-export const CHANNEL = '8db0a6b1-4d79-4ecd-8b7a-7ea5c1811764';
+export const CHANNEL = '0d0ac1f5-3d55-4854-86ec-2e8653dd16d4';
 
 export const MAIN = 'M' + CHANNEL;
 export const THREAD = 'T' + CHANNEL;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coincident",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coincident",
-      "version": "0.13.5",
+      "version": "0.13.6",
       "license": "ISC",
       "dependencies": {
         "@ungap/structured-clone": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,13 @@
         "ws": "8.14.2"
       },
       "devDependencies": {
-        "@playwright/test": "^1.38.1",
+        "@playwright/test": "^1.39.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
         "ascjs": "^6.0.2",
         "c8": "^8.0.1",
         "rollup": "^4.0.2",
-        "static-handler": "^0.4.2",
+        "static-handler": "^0.4.3",
         "typescript": "^5.2.2",
         "uhtml": "^3.2.2"
       },
@@ -114,12 +114,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
-      "integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
+      "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.38.1"
+        "playwright": "1.39.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -975,12 +975,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
-      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.38.1"
+        "playwright-core": "1.39.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -993,9 +993,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
-      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -1179,9 +1179,9 @@
       }
     },
     "node_modules/static-handler": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/static-handler/-/static-handler-0.4.2.tgz",
-      "integrity": "sha512-Szbk521mneb5npxg3SEyoufsHr2osAzxMy71W2zFCzLB8wLhHYvKUDCMkLY6imi+fIqkpfas3rzXGBQf99aeEA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/static-handler/-/static-handler-0.4.3.tgz",
+      "integrity": "sha512-rHi6vtxW/kjC+L18cRVAICAp/ymTjyvZHCPXIrejrlVrRrNxrVGk9FNCg+rC9wM7SpZ9euyjsr7tNVtqpA2iLA==",
       "dev": true,
       "dependencies": {
         "mime-types": "^2.1.35"

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "rollup:uhtml": "rollup --config rollup/uhtml.config.js",
     "rollup:window": "rollup --config rollup/window.config.js",
     "test": "c8 node test/index.js",
-    "test:integration": "static-handler --cors --coop --coep --corp . 2>/dev/null & SH_PID=$!; EXIT_CODE=0; playwright test test/ || EXIT_CODE=$?; kill $SH_PID 2>/dev/null; exit $EXIT_CODE",
+    "test:integration": "static-handler --coi . 2>/dev/null & SH_PID=$!; EXIT_CODE=0; playwright test test/ || EXIT_CODE=$?; kill $SH_PID 2>/dev/null; exit $EXIT_CODE",
     "test:server": "node test/server/main.cjs",
     "ts": "tsc -p .",
-    "server": "npx static-handler --cors --coop --coep --corp .",
+    "server": "npx static-handler --coi .",
     "size": "echo -e \"\\x1b[1mfile        size\\x1b[0m\"; echo \"es          $(cat es.js | brotli | wc -c)\"; echo \"structured  $(cat structured.js | brotli | wc -c)\"; echo \"window      $(cat window.js | brotli | wc -c)\"; echo \"server      $(cat server.js | brotli | wc -c)\"; echo \"uhtml       $(cat uhtml.js | brotli | wc -c)\";",
     "coverage": "mkdir -p ./coverage; c8 report --reporter=text-lcov > ./coverage/lcov.info"
   },
@@ -29,13 +29,13 @@
   "author": "Andrea Giammarchi",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.38.1",
+    "@playwright/test": "^1.39.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",
     "ascjs": "^6.0.2",
     "c8": "^8.0.1",
     "rollup": "^4.0.2",
-    "static-handler": "^0.4.2",
+    "static-handler": "^0.4.3",
     "typescript": "^5.2.2",
     "uhtml": "^3.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coincident",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "An Atomics based Proxy to simplify, and synchronize, Worker related tasks",
   "main": "./cjs/index.js",
   "types": "./types/index.d.ts",

--- a/test/issue-26/worker.js
+++ b/test/issue-26/worker.js
@@ -3,7 +3,7 @@ console.log('worker.js');
 import coincident from '../../es.js';
 const proxy = coincident(self);
 
-(async () => {
-  for (let i = 0; i < 100000; i++)
-    proxy.func();
-})();
+for (let i = 0; i < 100000; i++)
+  proxy.func();
+
+console.log('DONE');


### PR DESCRIPTION
This MR uses what seems to be the best way to deal with `Atomics.wait(view, index, control, ...rest)` which is by doubling the buffer for the "*first contact*" and reading the result out of the `view[1]` index instead, reserving `view[0]` for just the control value.

This MRs also avoid locking forever workers when stuff breaks on *main* so that they can be freed and an error will be still thrown when/if needed, without actually letting workers hang forever.

To know more about this solution please read the ugly exchange at Mozilla https://bugzilla.mozilla.org/show_bug.cgi?id=1858092#c7 but after testing current branch in all major browsers I am confident this is the right thing to do, even if the previous hack on `-1` was already solving the issue.