### PR TITLE
Fix #29 - Distribute results over safe arity length

### DIFF
--- a/esm/channel.js
+++ b/esm/channel.js
@@ -1,5 +1,5 @@
 // ⚠️ AUTOMATICALLY GENERATED - DO NOT CHANGE
-export const CHANNEL = '5fef2bcc-cb2a-497f-9cb0-9cc2e2f09eea';
+export const CHANNEL = 'e1b3818a-2a8a-4b7b-8baa-cc9bb34a53a3';
 
 export const MAIN = 'M' + CHANNEL;
 export const THREAD = 'T' + CHANNEL;

--- a/esm/index.js
+++ b/esm/index.js
@@ -11,6 +11,10 @@ const {Int32Array, Map, SharedArrayBuffer, Uint16Array} = globalThis;
 const {BYTES_PER_ELEMENT: I32_BYTES} = Int32Array;
 const {BYTES_PER_ELEMENT: UI16_BYTES} = Uint16Array;
 
+// @see https://github.com/WebReflection/coincident/issues/29
+// @see http://webreflection.blogspot.com/2011/07/about-javascript-apply-arguments-limit.html
+const SAFE_ARITY_LENGTH = 2048;
+
 const {isArray} = Array;
 const {notify, wait, waitAsync} = Atomics;
 const {fromCharCode} = String;
@@ -113,10 +117,14 @@ const coincident = (self, {parse = JSON.parse, stringify = JSON.stringify, trans
 
           // ask for results and wait for it
           post([], id, sb);
-          return waitFor(isAsync, sb).value.then(
+          return waitFor(isAsync, sb).value.then(() => {
             // transform the shared buffer into a string and return it parsed
-            () => parse(fromCharCode(...new Uint16Array(sb.buffer).slice(0, length)))
-          );
+            const uint16 = new Uint16Array(sb.buffer).slice(0, length);
+            const result = [];
+            for (let i = 0; i < length; i += SAFE_ARITY_LENGTH)
+              result.push(fromCharCode(...uint16.slice(i, i + SAFE_ARITY_LENGTH)));
+            return parse(result.join(''));
+          });
         });
       }),
 

--- a/test/too-big/index.html
+++ b/test/too-big/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type="module">
+    import coincident from '../../es.js';
+    const proxy = coincident(new Worker('./worker.js', {type: 'module'}));
+    proxy.func = () => {
+      let buf = new ArrayBuffer(51111);
+      return new Uint8Array(buf);
+    };
+  </script>
+</head>
+</html>

--- a/test/too-big/worker.js
+++ b/test/too-big/worker.js
@@ -1,0 +1,5 @@
+import coincident from '../../es.js';
+const proxy = coincident(self);
+
+let x = proxy.func();
+console.log("len: ", Object.keys(x).length);


### PR DESCRIPTION
This MR fixes the issue raised in https://github.com/WebReflection/coincident/issues/29