### PR TITLE
WIP: trying to understand benefits of "direct buffers"

### DIFF
--- a/esm/channel.js
+++ b/esm/channel.js
@@ -1,5 +1,5 @@
 // ⚠️ AUTOMATICALLY GENERATED - DO NOT CHANGE
-export const CHANNEL = 'bd08544f-7f25-4cbf-bc51-5d35235131ca';
+export const CHANNEL = '886414b0-8354-49a9-a3ef-6c564d692307';
 
 export const MAIN = 'M' + CHANNEL;
 export const THREAD = 'T' + CHANNEL;

--- a/test/too-big/index.html
+++ b/test/too-big/index.html
@@ -7,8 +7,10 @@
     import coincident from '../../es.js';
     const proxy = coincident(new Worker('./worker.js', {type: 'module'}));
     proxy.func = () => {
-      let buf = new ArrayBuffer(51111);
-      return new Uint8Array(buf);
+      const buf = new ArrayBuffer(51111);
+      const result = new Uint8Array(buf);
+      result[0] = 1;
+      return result;
     };
   </script>
 </head>


### PR DESCRIPTION
This MR tries to address #31 **but**:

  * to not lose the *kind* of typed view, it's still necessary to convert the typed array into a string somehow
  * because the SharedArrayBuffer with Atomics works only with an [Int32Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array) or [BigInt64Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array), there's no way to pollute directly the *SAB* with generic typed views
  * accordingly, as everything boils down to a string, and `charCodeAt` and `TextDecoder.decode` are still needed, it's unclear how much memory or performance boost one can gain by branching logic and bypassing serialization

I might just also quick check both times and see if it's substantially faster to do this way, but I think I am going to close this and flag the related issue as **won't fix**.