### PR TITLE
Workaround for broken Proxies

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,7 @@ import {
   result,
   set,
   stop,
+  ffi_no_symbol,
   ffi_timeout,
 } from './utils.js';
 
@@ -123,7 +124,12 @@ export default options => {
         });
       }
 
-      super.postMessage([UID, serviceWorker, ffi_timeout(options, timeout)], [port2]);
+      super.postMessage([
+        UID,
+        serviceWorker,
+        ffi_timeout(options, timeout),
+        ffi_no_symbol(options),
+      ], [port2]);
 
       channel.addEventListener('message', async ({ data }) => {
         const i32 = data[0];

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,6 +39,8 @@ const stop = event => {
   event.preventDefault();
 };
 
+export const ffi_no_symbol = options => !!options?.reflected_ffi_no_symbol;
+
 export const ffi_timeout = (options, fallback = -1) => (
   options?.reflected_ffi_timeout ?? fallback
 );

--- a/src/window/constants.js
+++ b/src/window/constants.js
@@ -1,4 +1,4 @@
 // ⚠️ AUTOMATICALLY GENERATED - DO NOT CHANGE
-const CHANNEL = '677caa6a';
+const CHANNEL = '4795617b';
 export const MAIN = '=' + CHANNEL;
 export const WORKER = '-' + CHANNEL;

--- a/src/window/worker.js
+++ b/src/window/worker.js
@@ -23,6 +23,7 @@ export default /** @type {Coincident} */ async options => {
     buffer: true,
     reflect: exports.proxy[MAIN],
     timeout: exports.ffi_timeout,
+    noSymbol: exports.ffi_no_symbol,
   });
 
   exports.proxy[WORKER] = ffi.reflect;

--- a/src/worker.js
+++ b/src/worker.js
@@ -30,19 +30,23 @@ addEventListener(
   'message',
   event => {
     stop(event);
-    const [ID, SW, ffi_timeout] = event.data;
+    const [ID, SW, ffi_timeout, ffi_no_symbol] = event.data;
     const [channel] = event.ports;
     if (SW) {
       setPrototypeOf(channel, MPP);
       if (ID) postMessage = sabayon.postMessage;
     }
-    bootstrap.resolve([ID, SW, ffi_timeout, channel]);
+    bootstrap.resolve([ID, SW, ffi_timeout, ffi_no_symbol, channel]);
   },
   { once: true }
 );
 
 export default async options => {
-  const [ID, SW, ffi_timeout, channel] = await sabayon.register().then(() => bootstrap.promise);
+  const [
+    ID, SW,
+    ffi_timeout, ffi_no_symbol,
+    channel,
+  ] = await sabayon.register().then(() => bootstrap.promise);
   const WORKAROUND = !!ID;
   const direct = native || !!SW;
   const transform = options?.transform;
@@ -124,6 +128,7 @@ export default async options => {
     native,
     proxy,
     ffi_timeout,
+    ffi_no_symbol,
     sync: direct,
     transfer: transferred.set,
   };


### PR DESCRIPTION
This follows up the following change https://github.com/WebReflection/reflected-ffi/pull/7

It requires latest *reflected-ffi* module in order to work.

Upstream bug: https://github.com/micropython/micropython/pull/17604